### PR TITLE
Php 7.2 compatibilty

### DIFF
--- a/desktop/php/sonybravia.php
+++ b/desktop/php/sonybravia.php
@@ -74,7 +74,7 @@ foreach ($eqLogics as $eqLogic) {
                         <select class="form-control eqLogicAttr" data-l1key="object_id">
                             <option value="">{{Aucun}}</option>
                             <?php
-foreach (object::all() as $object) {
+foreach (jeeObject::all() as $object) {
 	echo '<option value="' . $object->getId() . '">' . $object->getName() . '</option>';
 }
 ?>


### PR DESCRIPTION
From version `7.2` of Php, `object` is a reserved keyword ([documentation](https://www.php.net/manual/fr/reserved.other-reserved-words.php))

In current state, the plugin does not work with this php version, which is the baseline version of latest ubuntu LTS (bionic beaver)